### PR TITLE
Document workaround for encoding error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,11 @@ sensitive credentials.
 
 ![](doc/source/images/inserted_pandas.png)
 
+> Note: There is an [issue](https://github.com/IBM/pixiedust-facebook-analysis/issues/39) that causes failure of non utf-8 encodings that requires a workaround. You would fix this in the cell above by adding an encoding parameter to read_csv(). For our `example_facebook_data.csv`:
+```
+df_data_1 = pd.read_csv(body, encoding='latin-1')
+```
+
 #### Fix-up variable names
 The inserted code includes a generated method with credentials and then calls
 the generated method to set a variable with a name like `df_data_1`. If you do

--- a/notebooks/pixiedust_facebook_analysis.ipynb
+++ b/notebooks/pixiedust_facebook_analysis.ipynb
@@ -266,6 +266,12 @@
     "\n",
     "**Select the cell below and place your cursor on an empty line below the comment.** Load the CSV file you want to enrich by clicking on the 10/01 icon (upper right), then click `Insert to code` under the file you want to enrich, and choose `Insert Pandas DataFrame`.\n",
     "\n",
+    "Note: There is an issue (https://github.com/IBM/pixiedust-facebook-analysis/issues/39)\n",
+    " that causes failure of non utf-8 encodings that requires a workaround.\n",
+    " You would fix this in the cell below by adding an encoding parameter to read_csv(). For our example_facebook_data.csv:\n",
+   "\n",
+   "  `df_data_1 = pd.read_csv(body, encoding='latin-1')` ",
+   "\n",
     "###  <span style=\"color: red\"> _User Input_</span> "
    ]
   },


### PR DESCRIPTION
Due to Issue
[#39](https://github.com/IBM/pixiedust-facebook-analysis/issues/39)
the generated code from inserting a pandas dataframe will fail in
python 3 when using new Cloud Object Storage.
Work around this by adding an explicit encoding parameter.
This will be fixed in the generated code, but for now we need
to document.

Partial Fix: #39